### PR TITLE
Update migration.sql to avoid syntax errors

### DIFF
--- a/database/migration.sql
+++ b/database/migration.sql
@@ -12,7 +12,7 @@ CREATE TABLE `users` (
     `license` varchar(255) NOT NULL,
     `created_at` TimeStamp,
     `updated_at` TimeStamp,
-    PRIMARY KEY (`id`),
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `characters` (


### PR DESCRIPTION
Delete the comma on line 15 after the PRIMARY KEY (`id`) to avoid syntax errors in recipe execution.